### PR TITLE
Update DecisionTreeModel.R

### DIFF
--- a/DecisionTreeModel.R
+++ b/DecisionTreeModel.R
@@ -29,7 +29,7 @@ set.seed(1000)
 split = sample.split(loan1, SplitRatio = 0.5)
 loan3 = subset(loan1, split==TRUE)
 loan<-rbind(loan3,loan2)
-table(loan$loan_decision[loan$loan_decision=="NO"])/table(loan$loan_decision[loan$loan_decision=="YES"])
+table(loan$loan_decision[loan$loan_decision==0])/table(loan$loan_decision[loan$loan_decision==1])
 #24% negative values for dependent variable
 
 #creating "verified" column


### PR DESCRIPTION
In Line no 32 loan decision attribute were compared with "YES" or "NO". While in the actual value are 0 and 1.

code :
table(loan$loan_decision[loan$loan_decision=="Yes"])/table(loan$loan_decision[loan$loan_decision==""NO"])

Results:
numeric(0)

Modified code:
table(loan$loan_decision[loan$loan_decision==0])/table(loan$loan_decision[loan$loan_decision==1])

Results:
0.2391013
